### PR TITLE
MD2 version with up to 1MB ROM support, run ROM from Flash

### DIFF
--- a/code/singleROM/bin2c.py
+++ b/code/singleROM/bin2c.py
@@ -31,7 +31,7 @@ with open( dstFile, "w" ) as f:
   # First, define the address mask.
   addressBits = math.ceil( math.log2( len( outStr ) ) )
   
-  curLine = "unsigned char rom[ " + str( len( outStr ) ) + " ] = {\n"
+  curLine = "const unsigned char rom[ " + str( len( outStr ) ) + " ] = {\n"
   f.write( curLine )
   tmpCnt = 0
   firstLine = True

--- a/code/singleROM/main.c
+++ b/code/singleROM/main.c
@@ -1,5 +1,6 @@
 #include "pico/stdlib.h"
 #include <stdlib.h>
+#include "hardware/clocks.h"
 
 #include "rom.h"
 

--- a/code/singleROM/main.c
+++ b/code/singleROM/main.c
@@ -57,7 +57,7 @@
 //                     76543210
 #define DATAMASKLOW  0b01111111
 #define DATAMASKHIGH 0b10000000
-#define BANKMASK     0b00011111
+#define BANKMASK     0b00111111  // Supports banks 0-63
 
 
 void initGPIO() {
@@ -85,10 +85,23 @@ const unsigned char * p_rombank_offsets[] = {
     ROM_BANK(4),  ROM_BANK(5),  ROM_BANK(6),  ROM_BANK(7), // 128K
     ROM_BANK(8),  ROM_BANK(9),  ROM_BANK(10), ROM_BANK(11),
     ROM_BANK(12), ROM_BANK(13), ROM_BANK(14), ROM_BANK(15), // 256K
+
     ROM_BANK(16), ROM_BANK(17), ROM_BANK(18), ROM_BANK(19),
     ROM_BANK(20), ROM_BANK(21), ROM_BANK(22), ROM_BANK(23),
     ROM_BANK(24), ROM_BANK(25), ROM_BANK(26), ROM_BANK(27),
     ROM_BANK(28), ROM_BANK(29), ROM_BANK(30), ROM_BANK(31), // 512K
+
+    ROM_BANK(32), ROM_BANK(33), ROM_BANK(34), ROM_BANK(35),
+    ROM_BANK(36), ROM_BANK(37), ROM_BANK(38), ROM_BANK(39),
+    ROM_BANK(40), ROM_BANK(41), ROM_BANK(42), ROM_BANK(43),
+    ROM_BANK(44), ROM_BANK(45), ROM_BANK(46), ROM_BANK(47),
+
+    ROM_BANK(48), ROM_BANK(49), ROM_BANK(50), ROM_BANK(51),
+    ROM_BANK(52), ROM_BANK(53), ROM_BANK(54), ROM_BANK(55),
+    ROM_BANK(56), ROM_BANK(57), ROM_BANK(58), ROM_BANK(59),
+    ROM_BANK(60), ROM_BANK(61), ROM_BANK(62), ROM_BANK(63), // 1MB
+
+
 };
 
 void __not_in_flash_func( handleROM_MD2() ) {
@@ -126,8 +139,7 @@ void __not_in_flash_func( handleROM_MD2() ) {
     if ( wr ) {
       // Handle MD2 style bank switch register write at address 0x0001
       if (addr == 0x0001) {
-          // rom_bank_num = ( data & LOWDATAMASK ) & ( BANKMASK << DATAOFFSETLOW );
-          rombank = p_rombank_offsets[(data >> 16) & BANKMASK];
+          rombank = p_rombank_offsets[(data >> DATAOFFSETLOW) & BANKMASK];
       }
     }
   }

--- a/code/singleROM/main.c
+++ b/code/singleROM/main.c
@@ -42,15 +42,20 @@
 #define RSTMS 100
 
 // Bit masks.
-#define ADDRMASK 0b00000000000000001111111111111111
-#define DATAMASK 0b00000100011111110000000000000000
+#define ADDRMASK    0b00000000000000001111111111111111
+#define DATAMASK    0b00000100011111110000000000000000
+//                                    FEDCBA9876543210
+//                    FEDCBA9876543210
 #define LOWDATAMASK 0b00000000011111110000000000000000
-#define NWRMASK  0b00001000000000000000000000000000
-#define RSTMASK  0b00010000000000000000000000000000
-#define A15MASK  0b00000000000000001000000000000000
+#define NWRMASK     0b00001000000000000000000000000000
+#define RSTMASK     0b00010000000000000000000000000000
+#define A15MASK     0b00000000000000001000000000000000
 
+//                     76543210
 #define DATAMASKLOW  0b01111111
 #define DATAMASKHIGH 0b10000000
+#define BANKMASK     0b00011111
+// #define BANKMASK     0b00000111
 
 // Bank switch
 // 1: Dynamic 32 kB banks (e.g., Puppet Knight)
@@ -71,9 +76,13 @@ void initGPIO() {
   gpio_set_dir( RST, GPIO_OUT );
 }
 
+#define ROM_BANK(N) (rom + ((N-1) * 0x4000u)) // The reason for N-1 is because rombank will be accessed with a base of (0x4000) + the bank relative address
+
+// pico pi 2040: 264kB of SRAM, 2MB of flash storage
+
 void __not_in_flash_func( handleROM() ) {
-  // Initial bank.
-  uint8_t* rombank = rom;
+  // Initial bank, point it to BANK 1
+  const uint8_t * rombank = ROM_BANK(1); // rom;
   
   // Start endless loop.
   while( 1 ) {
@@ -133,39 +142,54 @@ void __not_in_flash_func( handleROM() ) {
           // Bank switch type 2
           BANKSWITCH = 2;
           
-          writeData = ( data & LOWDATAMASK ) & ( 0b111 << DATAOFFSETLOW );
-          
+          writeData = ( data & LOWDATAMASK ) & ( BANKMASK << DATAOFFSETLOW );
+
           // Use a case structure instead of a dynamic multiplcation
           // to hopefully speed up things.
           switch ( writeData ) {
             case 0:
-            case ( 1 << DATAOFFSETLOW ):
-              rombank = rom + 0; 
-              break;
-              
-            case ( 2 << DATAOFFSETLOW ):
-              rombank = rom + 1 * 16384;
-              break;
-              
-            case ( 3 << DATAOFFSETLOW ):
-              rombank = rom + 2 * 16384;
-              break;
-              
-            case ( 4 << DATAOFFSETLOW ):
-              rombank = rom + 3 * 16384;
-              break;
-              
-            case ( 5 << DATAOFFSETLOW ):
-              rombank = rom + 4 * 16384;
-              break;
-              
-            case ( 6 << DATAOFFSETLOW ):
-              rombank = rom + 5 * 16384;
-              break;
-              
-            case ( 7 << DATAOFFSETLOW ):
-              rombank = rom + 6 * 16384;
-              break;
+            case ( 1  << DATAOFFSETLOW ): rombank = ROM_BANK(1); break;
+            // End 32K
+            // 
+            case ( 2  << DATAOFFSETLOW ): rombank = ROM_BANK(2); break;
+            case ( 3  << DATAOFFSETLOW ): rombank = ROM_BANK(3); break;
+            // End 64K
+            
+            case ( 4  << DATAOFFSETLOW ): rombank = ROM_BANK(4); break;
+            case ( 5  << DATAOFFSETLOW ): rombank = ROM_BANK(5); break;
+            case ( 6  << DATAOFFSETLOW ): rombank = ROM_BANK(6); break;
+            case ( 7  << DATAOFFSETLOW ): rombank = ROM_BANK(7); break;
+            // End 128K
+            
+            case ( 8  << DATAOFFSETLOW ): rombank = ROM_BANK(8); break;
+            case ( 9  << DATAOFFSETLOW ): rombank = ROM_BANK(9); break;
+            case ( 10 << DATAOFFSETLOW ): rombank = ROM_BANK(10); break;
+            case ( 11 << DATAOFFSETLOW ): rombank = ROM_BANK(11); break;
+            case ( 12 << DATAOFFSETLOW ): rombank = ROM_BANK(12); break;
+            case ( 13 << DATAOFFSETLOW ): rombank = ROM_BANK(13); break;
+            case ( 14 << DATAOFFSETLOW ): rombank = ROM_BANK(14); break;
+            case ( 15 << DATAOFFSETLOW ): rombank = ROM_BANK(15); break;            
+            // End 256K (seems ok)
+
+            case ( 16 << DATAOFFSETLOW ): rombank = ROM_BANK(16); break;
+            case ( 17 << DATAOFFSETLOW ): rombank = ROM_BANK(17); break;
+            case ( 18 << DATAOFFSETLOW ): rombank = ROM_BANK(18); break;
+            case ( 19 << DATAOFFSETLOW ): rombank = ROM_BANK(19); break;
+            case ( 20 << DATAOFFSETLOW ): rombank = ROM_BANK(20); break;
+            case ( 21 << DATAOFFSETLOW ): rombank = ROM_BANK(21); break;
+            case ( 22 << DATAOFFSETLOW ): rombank = ROM_BANK(22); break;
+            case ( 23 << DATAOFFSETLOW ): rombank = ROM_BANK(23); break;
+            
+            case ( 24 << DATAOFFSETLOW ): rombank = ROM_BANK(24); break;
+            case ( 25 << DATAOFFSETLOW ): rombank = ROM_BANK(25); break;
+            case ( 26 << DATAOFFSETLOW ): rombank = ROM_BANK(26); break;
+            case ( 27 << DATAOFFSETLOW ): rombank = ROM_BANK(27); break;
+            case ( 28 << DATAOFFSETLOW ): rombank = ROM_BANK(28); break;
+            case ( 29 << DATAOFFSETLOW ): rombank = ROM_BANK(29); break;
+            case ( 30 << DATAOFFSETLOW ): rombank = ROM_BANK(30); break;
+            case ( 31 << DATAOFFSETLOW ): rombank = ROM_BANK(31); break;
+            // End 512K (seems ok)
+
 
             // Something went wrong.
             default:


### PR DESCRIPTION
This makes some changes to add support for up to 1MB ROMs using the MD2 type mbc (Banks 0-63)
- Run the ROM from FLASH instead of RAM
- To get the apparent speed needed (games crash otherwise), only supports MD2 type mbc and strips the code down a bit
- May require building with the newer pico SDK (2.0?), had to add `#include "hardware/clocks.h"`